### PR TITLE
Only run CI on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: Build Binaries
 
 on:
   push:
-  pull_request:
 
 jobs:
   build-arm:


### PR DESCRIPTION
The CI caching creates issues when run in a PR. For this reason, we rather should run the CI on push rather than PR. 